### PR TITLE
ci: disable include-component-in-tag

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -20,6 +20,7 @@
   ],
   "packages": {
     ".": {
+      "include-component-in-tag": false,
       "release-type": "node",
       "changelog-path": "CHANGELOG.md"
     }


### PR DESCRIPTION
This pull request includes a small change to the `release-please-config.json` file. The change disables the inclusion of the component in the tag for the root package.

* [`release-please-config.json`](diffhunk://#diff-c55d4dcb68c348b2c06d263819702fbce72eeeb35b662956d02049a5a18fcf2bR23): Set `"include-component-in-tag"` to `false` for the root package.